### PR TITLE
chore: enable embedded-language-formatting

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,1 @@
+embeddedLanguageFormatting: auto


### PR DESCRIPTION
このprettierのオプションを有効にすることで、テンプレートリテラル内のマークアップに整形が効くようになるはず
参考: https://prettier.io/blog/2020/08/24/2.1.0.html#add---embedded-language-formattingautooff-option-7875httpsgithubcomprettierprettierpull7875-by-bakkothttpsgithubcombakkot-8825httpsgithubcomprettierprettierpull8825-by-fiskerhttpsgithubcomfisker