### PR TITLE
fix(html.js): cjsでesmの定義をしている&適切に変数展開されない

### DIFF
--- a/packages/tailwindcss/stories/html.js
+++ b/packages/tailwindcss/stories/html.js
@@ -1,4 +1,9 @@
 /* テンプレート文字列のマークアップを整形する際に使用するタグ関数
  * See: https://prettier.io/blog/2020/08/24/2.1.0.html#add---embedded-language-formattingautooff-option-7875httpsgithubcomprettierprettierpull7875-by-bakkothttpsgithubcombakkot-8825httpsgithubcomprettierprettierpull8825-by-fiskerhttpsgithubcomfisker
  */
-export default (html) => html;
+const html = (strings, ...args) =>
+  strings.reduce(
+    (previous, current, index) => previous + args[index - 1] + current
+  );
+
+module.exports = html;


### PR DESCRIPTION
関連: #96 https://github.com/tuqulore/tuqulore-ui/pull/98#issuecomment-953632865 https://github.com/tuqulore/tuqulore-ui/issues/62#issuecomment-953452228

確認したこと

このブランチでhtml.jsを読み込んでいるstoriyで適切にコンポーネントが表示されること