### PR TITLE
chore: Storybookのストーリの並びの調整

### DIFF
--- a/packages/tailwindcss/.storybook/preview.js
+++ b/packages/tailwindcss/.storybook/preview.js
@@ -8,4 +8,9 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  options: {
+    storySort: {
+      order: ["Overview", "*", "Galleries"],
+    },
+  },
 };


### PR DESCRIPTION
概要が最初に表示され、ギャラリーは最後に表示されるような並びの調整をしました

参考: https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy#sorting-stories