### PR TITLE
feat: プレースホルダーでのアイコンの使用をとりやめる

### DIFF
--- a/packages/tailwindcss/input.js
+++ b/packages/tailwindcss/input.js
@@ -23,15 +23,6 @@ module.exports = plugin.withOptions(
           },
         },
         {
-          ".input-icon": {
-            "&::placeholder": {
-              "font-family": "'Font Awesome 5 Free'",
-              fontWeight: 900,
-              fontSize: theme("fontSize.sm"),
-            },
-          },
-        },
-        {
           "[type='checkbox'], [type='radio']": {
             appearance: "none",
             padding: "0",

--- a/packages/tailwindcss/stories/Input.stories.mdx
+++ b/packages/tailwindcss/stories/Input.stories.mdx
@@ -21,11 +21,11 @@ import html from "./html";
     {html` <p class="mb-4">Font Awesome 5を使った例です</p>
       <div class="mt-4">
         <h3 class="mb-1"><i class="fas fa-search"></i> 検索</h3>
-        <input type="text" class="input-icon" placeholder="&#xf002; 検索" />
+        <input type="text" placeholder="タイトル、著者、etc." />
       </div>
       <div class="mt-4">
         <h3 class="mb-1"><i class="fas fa-envelope"></i> メール</h3>
-        <input type="email" class="input-icon" placeholder="&#xf0e0; メール" />
+        <input type="email" placeholder="user@example.com" />
       </div>`}
   </Story>
 </Canvas>


### PR DESCRIPTION
関連: https://github.com/tuqulore/jumpu-ui/issues/35

もし入力欄内にアイコンがほしいのであれば、入力欄に隣接した部分に
常時表示すべきであって、入力すると消えるプレースホルダーには
適していないように思ったため

before
![image](https://user-images.githubusercontent.com/9744580/157635976-687371d5-fde6-47ef-81c9-f29468031b7f.png)

after
![image](https://user-images.githubusercontent.com/9744580/157636082-f6cbc512-11a6-43ea-81de-0acc2ee402c9.png)
