### PR TITLE
fix: missing dependencies mini-svg-data-uri

### DIFF
--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -37,8 +37,10 @@
     "autoprefixer": "^10.3.2",
     "babel-loader": "^8.2.2",
     "clsx": "^1.1.1",
-    "mini-svg-data-uri": "^1.3.3",
     "postcss": "^8.3.6",
     "tailwindcss": "^2.2.7"
+  },
+  "dependencies": {
+    "mini-svg-data-uri": "^1.3.3"
   }
 }


### PR DESCRIPTION
パッケージ利用時 `module not found` となる現象への対応