### PR TITLE
chore(lerna): 許容するブランチ名の変更

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
       "registry": "https://registry.npmjs.org"
     },
     "version": {
-      "allowBranch": ["main", "develop"],
+      "allowBranch": ["chore-release"],
       "conventionalCommits": true
     }
   }


### PR DESCRIPTION
リリースは必ず `chore-release`
というブランチを切っておこなうことにする
`main` あるいは `develop` で直接おこなうことはない