### PR TITLE
chore(release): v1.0.1-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-alpha.1](https://github.com/tuqulore/tuqulore-ui/compare/v1.0.1-alpha.0...v1.0.1-alpha.1) (2022-03-14)
+
+### Bug Fixes
+
+* missing dependencies mini-svg-data-uri ([00f0e4c](https://github.com/tuqulore/tuqulore-ui/commit/00f0e4cdba5a1abaebff76bdde4056133f493492))
+* **workflows:** ダイアログでリリースが止まる ([68823d9](https://github.com/tuqulore/tuqulore-ui/commit/68823d9f689dd017b7695632d1fa4120b3029151))
+
 ## 1.0.1-alpha.0 (2022-03-11)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,15 +1,18 @@
 {
-  "version": "1.0.1-alpha.0",
+  "version": "1.0.1-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "command": {
     "publish": {
-      "message": "chore(release): publish %s",
       "registry": "https://registry.npmjs.org"
     },
     "version": {
-      "allowBranch": ["chore-release"],
+      "allowBranch": [
+        "chore-release"
+      ],
       "conventionalCommits": true
     }
   }

--- a/packages/tailwindcss/CHANGELOG.md
+++ b/packages/tailwindcss/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-alpha.1](https://github.com/tuqulore/tuqulore-ui/compare/v1.0.1-alpha.0...v1.0.1-alpha.1) (2022-03-14)
+
+### Bug Fixes
+
+* missing dependencies mini-svg-data-uri ([00f0e4c](https://github.com/tuqulore/tuqulore-ui/commit/00f0e4cdba5a1abaebff76bdde4056133f493492))
+
 ## 1.0.1-alpha.0 (2022-03-11)
 
 ### Bug Fixes

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jumpu-ui/tailwindcss",
   "description": "A Tailwind CSS plugin which serve basic components designed by tuqulore inc.",
-  "version": "1.0.1-alpha.0",
+  "version": "1.0.1-alpha.1",
   "author": "tuqulore inc.",
   "bugs": {
     "url": "https://github.com/tuqulore/tuqulore-ui/issues"


### PR DESCRIPTION
## [1.0.1-alpha.1](https://github.com/tuqulore/tuqulore-ui/compare/v1.0.1-alpha.0...v1.0.1-alpha.1) (2022-03-14)

### Bug Fixes

* missing dependencies mini-svg-data-uri ([00f0e4c](https://github.com/tuqulore/tuqulore-ui/commit/00f0e4cdba5a1abaebff76bdde4056133f493492))
* **workflows:** ダイアログでリリースが止まる ([68823d9](https://github.com/tuqulore/tuqulore-ui/commit/68823d9f689dd017b7695632d1fa4120b3029151))