### PR TITLE
refactor: 不要なthemeの設定を取り除く

### DIFF
--- a/packages/tailwindcss/theme.js
+++ b/packages/tailwindcss/theme.js
@@ -2,29 +2,10 @@ const colors = require("tailwindcss/colors");
 const relScale = require("./lib/relScale");
 
 module.exports = {
-  tuqulore: {
-    input: {
-      radius: "8px",
-    },
-  },
   extend: {
     spacing: relScale,
     colors: {
-      primary: {
-        ...colors.blue,
-      },
-      tq: {
-        50: "#FFE6EB",
-        100: "#FFCCD5",
-        200: "#FF99AB",
-        300: "#FF6682",
-        400: "#FF3358",
-        500: "#FF002E",
-        600: "#BF0023",
-        700: "#800017",
-        800: "#40000C",
-        900: "#1A0005",
-      },
+      primary: colors.blue,
       white: colors.white,
       black: colors.black,
       success: "#00A93E",


### PR DESCRIPTION
いずれのコンポーネントからも参照されない設定は提供しないほうが
管理するコードの肥大化を防ぐことができ望ましいため