### PR TITLE
feat: `outline: "none"` を取り除く

### DIFF
--- a/packages/tailwindcss/accordion.js
+++ b/packages/tailwindcss/accordion.js
@@ -16,7 +16,6 @@ module.exports = plugin.withOptions(
               alignItems: "center",
               border: `1px solid ${theme("colors.gray.300")}`,
               cursor: "pointer",
-              outline: "none",
               "&::before": {
                 content: "''",
                 display: "block",

--- a/packages/tailwindcss/button.js
+++ b/packages/tailwindcss/button.js
@@ -19,9 +19,6 @@ module.exports = plugin.withOptions(
             "&:active": {
               filter: "brightness(75%)",
             },
-            "&:focus": {
-              outline: "none",
-            },
             "&[disabled]": disabled,
           },
         },

--- a/packages/tailwindcss/iconButton.js
+++ b/packages/tailwindcss/iconButton.js
@@ -12,7 +12,6 @@ module.exports = plugin.withOptions(
             alignItems: "center",
             color: theme("colors.gray.600"),
             borderRadius: theme("borderRadius.md"),
-            outline: "none",
             width: theme("width.8"),
             height: theme("height.8"),
             position: "relative",
@@ -31,9 +30,6 @@ module.exports = plugin.withOptions(
               whiteSpace: "nowrap",
               color: theme("colors.white"),
               lineHeight: theme("lineHeight.tight"),
-            },
-            "&:focus": {
-              outline: "none",
             },
             "&:hover": {
               backgroundColor: theme("colors.gray.50"),

--- a/packages/tailwindcss/input.js
+++ b/packages/tailwindcss/input.js
@@ -46,7 +46,6 @@ module.exports = plugin.withOptions(
             "border-radius": theme("borderRadius.full"),
           },
           "[type='checkbox']:focus, [type='radio']:focus": {
-            outline: "none",
             "--tw-ring-inset": "var(--tw-empty,/*!*/ /*!*/)",
             "--tw-ring-offset-width": "2px",
             "--tw-ring-offset-color": "#fff",

--- a/packages/tailwindcss/lib/iconButtonStyle.js
+++ b/packages/tailwindcss/lib/iconButtonStyle.js
@@ -24,14 +24,10 @@ module.exports = (theme) => {
       backgroundColor: theme("colors.white"),
       borderRadius: theme("borderRadius.full"),
       border: `1px solid currentColor`,
-      outline: "none",
       overflow: "hidden",
       cursor: "pointer",
       position: "relative",
       color: theme("colors.primary.700"),
-      "&:focus": {
-        outline: "none",
-      },
       "&:hover": {
         backgroundColor: theme("colors.primary.50"),
       },

--- a/packages/tailwindcss/outlinedButton.js
+++ b/packages/tailwindcss/outlinedButton.js
@@ -22,9 +22,6 @@ module.exports = plugin.withOptions(
             "&:active": {
               filter: "brightness(110%)",
             },
-            "&:focus": {
-              outline: "none",
-            },
             "&[disabled]": {
               ...disabled,
               color: theme("colors.white"),


### PR DESCRIPTION
キーボード操作でウェブページを閲覧するユーザーにとっては
どの箇所にフォーカスが当たっているかの見た目の手がかりは重要であるため

参考: https://orememo-v2.tumblr.com/post/98123087427/outline-none
関連するWCAG: https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html

---

- `outline: "none"` を挿入していた背景について知りたいです（それが良いか悪いかに関わらず、なにか意図があったのであれば、それを理解したいです）
- `role="button"` を使用している箇所についても、同様にフォーカスの見た目を提供したほうがよさそう（参考: https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles/button_role#accessibility_concerns ）ですが、このPRでは対応しない想定です
- フォーカスの見た目の提供について、 https://tailwindcss.com/docs/ring-width などtailwindcssのring関連のスタイルを活用できるでしょうか？ご意見伺いたいです