### PR TITLE
chore(release): v1.0.1-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-alpha.4](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-04-06)
+
+### Bug Fixes
+
+* typo ([6c25959](https://github.com/tuqulore/jumpu-ui/commit/6c25959148fd2000cd6b7b6c784f2bc7d4c9c6e4))
+
 ## [1.0.1-alpha.3](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.1...v1.0.1-alpha.3) (2022-03-25)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1-alpha.3",
+  "version": "1.0.1-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/tailwindcss/CHANGELOG.md
+++ b/packages/tailwindcss/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-alpha.4](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-04-06)
+
+**Note:** Version bump only for package @jumpu-ui/tailwindcss
+
 ## [1.0.1-alpha.3](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.1...v1.0.1-alpha.3) (2022-03-25)
 
 ### Bug Fixes

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jumpu-ui/tailwindcss",
   "description": "A Tailwind CSS plugin which serve basic components designed by tuqulore inc.",
-  "version": "1.0.1-alpha.3",
+  "version": "1.0.1-alpha.4",
   "author": "tuqulore inc.",
   "bugs": {
     "url": "https://github.com/tuqulore/jumpu-ui/issues"


### PR DESCRIPTION
## [1.0.1-alpha.4](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-04-06)

### Bug Fixes

* typo ([6c25959](https://github.com/tuqulore/jumpu-ui/commit/6c25959148fd2000cd6b7b6c784f2bc7d4c9c6e4))

---

備考: READMEを用意してから最初のリリースなので、今回からREADMEが npmjs.org に反映されます