### PR TITLE
feat!: successの色がアクセシビリティ基準をクリアしていないのでFigma通りにする

### DIFF
--- a/packages/tailwindcss/colors.js
+++ b/packages/tailwindcss/colors.js
@@ -1,5 +1,5 @@
 module.exports = {
-  success: "#00A93E",
+  success: "#15803D",
   warning: "#FACC15",
   danger: "#B80000",
 };


### PR DESCRIPTION
storybookで指定しているsuccessの色 #00A93E
<img width="227" alt="image" src="https://user-images.githubusercontent.com/281424/183053419-acb6d3da-3a1a-4366-a8e8-ab7c2ea00f98.png">

Figmaで指定しているsuccessの色 #15803D

<img width="183" alt="image" src="https://user-images.githubusercontent.com/281424/183053466-2db472a6-9ef4-4274-afd3-6e34a1734080.png">


なぜかFigmaとsuccessの指定が違っていた。