### PR TITLE
fix: lerna-lite が動作しない

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint .",
-    "release": "ws-roller publish from-package",
-    "versionup": "ws-roller version --no-git-tag-version --no-push"
+    "release": "lerna publish from-package",
+    "versionup": "lerna version --no-git-tag-version --no-push"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
使用するcliの名称が変更されたため

See: https://github.com/ghiscoding/lerna-lite/blob/main/CHANGELOG.md#100-2022-03-15