### PR TITLE
chore(release): 1.0.1-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-alpha.5](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.4...v1.0.1-alpha.5) (2022-08-10)
+
+### Bug Fixes
+
+* idが重複しうる ([b5b304f](https://github.com/tuqulore/jumpu-ui/commit/b5b304febd15a4dcaebfa2854b2004976d85de43))
+* lerna-lite が動作しない ([#245](https://github.com/tuqulore/jumpu-ui/issues/245)) ([187eddf](https://github.com/tuqulore/jumpu-ui/commit/187eddfb4012e7169294530002037ecbe5661ba8)), closes [/github.com/ghiscoding/lerna-lite/blob/main/CHANGELOG.md#100-2022-03-15](https://github.com//github.com/ghiscoding/lerna-lite/blob/main/CHANGELOG.md/issues/100-2022-03-15)
+
+### Features
+
+* labelのドキュメント ([#234](https://github.com/tuqulore/jumpu-ui/issues/234)) ([8eaa0f2](https://github.com/tuqulore/jumpu-ui/commit/8eaa0f2e75f33f9205498ec5db2483c6e72cdfe9))
+* 色の整理 ([74f232c](https://github.com/tuqulore/jumpu-ui/commit/74f232c8f7adfe15e9fe90f77a5566e4c51e8e98))
+
+### BREAKING CHANGES
+
+* Please define colors yourself if already use predefined one
+* Please define success color yourself as `#00A93E` if already use
+
 ## [1.0.1-alpha.4](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-04-06)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1-alpha.4",
+  "version": "1.0.1-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/tailwindcss/CHANGELOG.md
+++ b/packages/tailwindcss/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1-alpha.5](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.4...v1.0.1-alpha.5) (2022-08-10)
+
+### Bug Fixes
+
+* idが重複しうる ([b5b304f](https://github.com/tuqulore/jumpu-ui/commit/b5b304febd15a4dcaebfa2854b2004976d85de43))
+
+### Features
+
+* labelのドキュメント ([#234](https://github.com/tuqulore/jumpu-ui/issues/234)) ([8eaa0f2](https://github.com/tuqulore/jumpu-ui/commit/8eaa0f2e75f33f9205498ec5db2483c6e72cdfe9))
+* 色の整理 ([74f232c](https://github.com/tuqulore/jumpu-ui/commit/74f232c8f7adfe15e9fe90f77a5566e4c51e8e98))
+
+### BREAKING CHANGES
+
+* Please define colors yourself if already use predefined one
+* Please define success color yourself as `#00A93E` if already use
+
 ## [1.0.1-alpha.4](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.3...v1.0.1-alpha.4) (2022-04-06)
 
 **Note:** Version bump only for package @jumpu-ui/tailwindcss

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jumpu-ui/tailwindcss",
   "description": "A Tailwind CSS plugin which serve basic components designed by tuqulore inc.",
-  "version": "1.0.1-alpha.4",
+  "version": "1.0.1-alpha.5",
   "author": "tuqulore inc.",
   "bugs": {
     "url": "https://github.com/tuqulore/jumpu-ui/issues"


### PR DESCRIPTION

## [1.0.1-alpha.5](https://github.com/tuqulore/jumpu-ui/compare/v1.0.1-alpha.4...v1.0.1-alpha.5) (2022-08-10)

### Bug Fixes

* idが重複しうる ([b5b304f](https://github.com/tuqulore/jumpu-ui/commit/b5b304febd15a4dcaebfa2854b2004976d85de43))
* lerna-lite が動作しない ([#245](https://github.com/tuqulore/jumpu-ui/issues/245)) ([187eddf](https://github.com/tuqulore/jumpu-ui/commit/187eddfb4012e7169294530002037ecbe5661ba8)), closes [/github.com/ghiscoding/lerna-lite/blob/main/CHANGELOG.md#100-2022-03-15](https://github.com//github.com/ghiscoding/lerna-lite/blob/main/CHANGELOG.md/issues/100-2022-03-15)

### Features

* labelのドキュメント ([#234](https://github.com/tuqulore/jumpu-ui/issues/234)) ([8eaa0f2](https://github.com/tuqulore/jumpu-ui/commit/8eaa0f2e75f33f9205498ec5db2483c6e72cdfe9))
* 色の整理 ([74f232c](https://github.com/tuqulore/jumpu-ui/commit/74f232c8f7adfe15e9fe90f77a5566e4c51e8e98))

### BREAKING CHANGES

* Please define colors yourself if already use predefined one
* Please define success color yourself as `#00A93E` if already use

