### PR TITLE
fix: loading ./Tag.stories.mdx: Module build failed

### DIFF
--- a/packages/tailwindcss/stories/Tag.stories.mdx
+++ b/packages/tailwindcss/stories/Tag.stories.mdx
@@ -75,7 +75,7 @@ import html from "./html";
 a 要素を用いる場合、通常はユーザーを異なるページへ移動させる目的があります。閉じるボタンによる削除という取り消せない操作で、異なるページへ移動できなくなる振る舞いは、まちがいなくユーザーを混乱させることでしょう。したがって、a 要素のタグにおいて閉じるボタンを用意することは推奨されません。
 
 <Canvas>
-  <Story name="Anchor">
+  <Story name="AnchorWithClose">
     {html`
       <a href="#" class="jumpu-tag ">
         デフォルト


### PR DESCRIPTION
fix #247

ローカルにて `yarn storybook` で起動したStorybookからTagが表示されることを確認した