### PR TITLE
fix: warn "Replace color-adjust to print-color-adjust"

### DIFF
--- a/packages/tailwindcss/input.js
+++ b/packages/tailwindcss/input.js
@@ -14,7 +14,7 @@ module.exports = plugin.withOptions(
           "&[type='checkbox'], &[type='radio']": {
             appearance: "none",
             padding: "0",
-            "color-adjust": "exact",
+            printColorAdjust: "exact",
             display: "inline-block",
             "vertical-align": "middle",
             "background-origin": "border-box",

--- a/packages/tailwindcss/select.js
+++ b/packages/tailwindcss/select.js
@@ -19,14 +19,14 @@ module.exports = plugin.withOptions(
           "background-repeat": `no-repeat`,
           "background-size": theme("spacing.rel6"),
           "padding-right": theme("spacing.10"),
-          "color-adjust": `exact`,
+          printColorAdjust: `exact`,
           "&[multiple]": {
             "background-image": "initial",
             "background-position": "initial",
             "background-repeat": "unset",
             "background-size": "initial",
             "padding-right": theme("spacing.3"),
-            "color-adjust": "unset",
+            printColorAdjust: "unset",
           },
         },
       });


### PR DESCRIPTION
fixed: #383 

`yarn dev` 時以下のようなメッセージが表示されないことを確認

```
[vite:css] Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.
1  |  @tailwind base;
2  |  @tailwind components;
   |   ^
3  |  @tailwind utilities;
4  |   (x3)

```