### PR TITLE
fix: 指定したパターンで story ファイルが存在しないと警告される

### DIFF
--- a/packages/tailwindcss/.storybook/main.js
+++ b/packages/tailwindcss/.storybook/main.js
@@ -1,8 +1,5 @@
 module.exports = {
-  stories: [
-    "../stories/**/*.stories.mdx",
-    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
-  ],
+  stories: ["../stories/**/*.stories.mdx"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",


### PR DESCRIPTION
`yarn dev` 時以下のようなメッセージが表示されることへの対応です`

`WARN No story files found for the specified pattern: stories/**/*.stories.@(js|jsx|ts|tsx)`