### PR TITLE
fix: storybook build に失敗

### DIFF
--- a/packages/tailwindcss/stories/Input.stories.mdx
+++ b/packages/tailwindcss/stories/Input.stories.mdx
@@ -49,9 +49,9 @@ import html from "./html";
 ### Number
 
 <Canvas>
-  <Story name="Number">{html`
-    <input type="number" class="jumpu-input" placeholder="0" />
-  `}</Story>
+  <Story name="Number">
+    {html` <input type="number" class="jumpu-input" placeholder="0" /> `}
+  </Story>
 </Canvas>
 
 ### Email

--- a/packages/tailwindcss/stories/Tag.stories.mdx
+++ b/packages/tailwindcss/stories/Tag.stories.mdx
@@ -46,25 +46,25 @@ import html from "./html";
 ### Anchor
 
 <Canvas>
-  <Story name="Anchor">{html`
-    <a href="#" class="jumpu-tag">デフォルト</a>
-  `}</Story>
+  <Story name="Anchor">
+    {html` <a href="#" class="jumpu-tag">デフォルト</a> `}
+  </Story>
 </Canvas>
 
 ### Button
 
 <Canvas>
-  <Story name="Button">{html`
-    <button class="jumpu-tag">デフォルト</button>
-  `}</Story>
+  <Story name="Button">
+    {html` <button class="jumpu-tag">デフォルト</button> `}
+  </Story>
 </Canvas>
 
 ### ARIA button role
 
 <Canvas>
-  <Story name="ARIA button role">{html`
-    <div class="jumpu-tag" tabindex="0" role="button">デフォルト</div>
-  `}</Story>
+  <Story name="ARIA button role">
+    {html` <div class="jumpu-tag" tabindex="0" role="button">デフォルト</div> `}
+  </Story>
 </Canvas>
 
 ### Closable


### PR DESCRIPTION
改行の有無により JSX 式の評価に失敗するケースがあるので対処します

```
WARN 🚨 Unable to index ./stories/Input.stories.mdx:
WARN   Error: Unexpected end of file in expression, expected a corresponding closing brace for `{`
WARN     at /home/runner/work/jumpu-ui/jumpu-ui/node_modules/@storybook/core-server/dist/index.js:23:2106
WARN     at async Promise.all (index 12)
WARN     at async Promise.all (index 0)
WARN     at async StoryIndexGenerator.updateExtracted (/home/runner/work/jumpu-ui/jumpu-ui/node_modules/@storybook/core-server/dist/index.js:23:1653)
WARN     at async StoryIndexGenerator.ensureExtracted (/home/runner/work/jumpu-ui/jumpu-ui/node_modules/@storybook/core-server/dist/index.js:23:2274)
WARN     at async StoryIndexGenerator.initialize (/home/runner/work/jumpu-ui/jumpu-ui/node_modules/@storybook/core-server/dist/index.js:23:1580)
```