### PR TITLE
fix: リリース用に割り当てられたブランチ名が不一致

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
     },
     "version": {
       "allowBranch": [
-        "chore-release"
+        "release"
       ],
       "conventionalCommits": true
     }


### PR DESCRIPTION
yarn versionup 時以下のメッセージが表示され失敗することへの対処

```
$ lerna version --no-git-tag-version patch --yes
lerna-lite notice cli v2.4.2
lerna-lite info ci enabled
lerna-lite info current project version 1.0.1-alpha.5
lerna-lite ERR! ENOTALLOWED Branch "release" is restricted from versioning due to allowBranch config.
lerna-lite ERR! ENOTALLOWED Please consider the reasons for this restriction before overriding the option.
lerna-lite ERR! Branch "release" is restricted from versioning due to allowBranch config.
lerna-lite ERR! Please consider the reasons for this restriction before overriding the option.
```