### PR TITLE
fix: git commit --message syntax error

### DIFF
--- a/.github/workflows/versionup.yaml
+++ b/.github/workflows/versionup.yaml
@@ -34,8 +34,8 @@ jobs:
           yarn versionup ${{ github.event.inputs.semver }} --yes
           NEXT_VERSION="v$(cat lerna.json | jq -r .version)"
           git commit --all \
-            --message "chore(release): ${NEXT_VERSION}"
-            --message "diff: https://github.com/tuqulore/jumpu-ui/compare/${PREV_VERSION}...${NEXT_VERSION}"
+            --message="chore(release): ${NEXT_VERSION}"
+            --message="diff: https://github.com/tuqulore/jumpu-ui/compare/${PREV_VERSION}...${NEXT_VERSION}"
           git push origin release
           gh pr create --fill
         env:


### PR DESCRIPTION
オプションとオプション引数の間に `=` が不足しており実行に失敗する点を修正します