### PR TITLE
fix: clean-css module not found

### DIFF
--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -36,6 +36,7 @@
     "@tailwindcss/typography": "0.5.9",
     "autoprefixer": "10.4.14",
     "babel-loader": "9.1.3",
+    "clean-css": "^5.3.2",
     "clsx": "1.2.1",
     "postcss": "8.4.25",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4263,6 +4263,13 @@ ci-info@^3.2.0, ci-info@^3.6.1:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
+clean-css@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.2.tgz#70ecc7d4d4114921f5d298349ff86a31a9975224"
+  integrity sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==
+  dependencies:
+    source-map "~0.6.0"
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -9328,7 +9335,7 @@ source-map-support@^0.5.16:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
fix of https://github.com/tuqulore/jumpu-ui/actions/runs/5538370539/jobs/10108239728

```console
$ lerna publish from-package --yes
lerna-lite notice cli v2.5.0
lerna-lite info ci enabled

Found 1 package to publish:
 - @jumpu-ui/tailwindcss => 1.0.1-alpha.6

lerna-lite info auto-confirmed 
lerna-lite info publish Publishing packages to npm...
lerna-lite notice Skipping all user and access validation due to third-party registry
lerna-lite notice Make sure you're authenticated properly "\_(ツ)_ /"
lerna-lite info lifecycle @jumpu-ui/tailwindcss@1.0.1-alpha.6~prepublishOnly: @jumpu-ui/tailwindcss@1.0.1-alpha.6

> @jumpu-ui/tailwindcss@1.0.1-alpha.6 prepublishOnly /home/runner/work/jumpu-ui/jumpu-ui/packages/tailwindcss
> node scripts/build.js

node:internal/modules/cjs/loader:1031
  throw err;
  ^

Error: Cannot find module 'clean-css'
```