### PR TITLE
Use theme static

### DIFF
--- a/packages/tailwindcss/src/colors.css
+++ b/packages/tailwindcss/src/colors.css
@@ -1,4 +1,4 @@
-@theme {
+@theme static {
   --color-danger: #b80000;
   --color-success: #15803d;
   --color-warning: #facc15;

--- a/packages/tailwindcss/src/theme.css
+++ b/packages/tailwindcss/src/theme.css
@@ -1,4 +1,4 @@
-@theme {
+@theme static {
   --color-primary-50: var(--color-blue-50);
   --color-primary-100: var(--color-blue-100);
   --color-primary-200: var(--color-blue-200);


### PR DESCRIPTION
生成した CSS に常に Jumpu UI が定義した CSS 変数を含めるようにします。

これにより、Taliwind CSS を使用しない環境でも Jumpu UI が提供するスタイルのフルセットが使用可能になります。