### PR TITLE
refactor(tailwindcss)!: serve CDN bundle via files, drop browser exports condition

### DIFF
--- a/packages/tailwindcss/README.md
+++ b/packages/tailwindcss/README.md
@@ -36,7 +36,10 @@ If you want to use partial styles, please import several CSS files from the pack
 If you want to use in client directly, you can use CDN as follows:
 
 ```html
-<link rel="stylesheet" href="https://esm.sh/@jumpu-ui/tailwindcss/dist/style.css" />
+<link
+  rel="stylesheet"
+  href="https://esm.sh/@jumpu-ui/tailwindcss/dist/style.css"
+/>
 ```
 
 > [!NOTE]

--- a/packages/tailwindcss/README.md
+++ b/packages/tailwindcss/README.md
@@ -36,7 +36,7 @@ If you want to use partial styles, please import several CSS files from the pack
 If you want to use in client directly, you can use CDN as follows:
 
 ```html
-<link rel="stylesheet" href="https://esm.sh/@jumpu-ui/tailwindcss" />
+<link rel="stylesheet" href="https://esm.sh/@jumpu-ui/tailwindcss/dist/style.css" />
 ```
 
 > [!NOTE]

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -14,16 +14,15 @@
   "author": "tuqulore inc.",
   "type": "module",
   "exports": {
-    ".": {
-      "browser": "./dist/style.css",
-      "default": "./src/style.css"
-    },
-    "./*": {
-      "browser": "./dist/*",
-      "default": "./src/*"
-    },
+    ".": "./src/style.css",
+    "./*": "./src/*",
     "./package.json": "./package.json"
   },
+  "files": [
+    "dist",
+    "src",
+    "NOTICE.md"
+  ],
   "scripts": {
     "lint": "stylelint './**/*.css' --ignore-path .gitignore",
     "prepublishOnly": "npx @tailwindcss/cli -i ./dist.css -o ./dist/style.css"


### PR DESCRIPTION
## Summary
- The `browser` exports condition was meant to give CDN consumers the pre-compiled `dist/style.css`, but bundlers also honor `browser`, so the dist was being handed to npm consumers too. PR #736 ordered `browser` before `default`, and Tailwind v4.2.3+ tightened Vite resolution ([tailwindlabs/tailwindcss#19803](https://github.com/tailwindlabs/tailwindcss/pull/19803)), which made `packageEntryFailure` surface for the workspace docs build whenever `dist/` was absent.
- Drop the `browser` exports condition entirely and serve the dist bundle via the `files` field at a stable path (`@jumpu-ui/tailwindcss/dist/style.css`). Bundlers resolve `src/style.css` through the new flat exports map, and CDN consumers reference the explicit dist path. `NOTICE.md` is added to `files` so it stays published once the field is set.
- README's CDN snippet updated accordingly.

## Breaking change
`https://esm.sh/@jumpu-ui/tailwindcss` (root path) no longer returns the pre-compiled CSS. CDN consumers must update to `https://esm.sh/@jumpu-ui/tailwindcss/dist/style.css`.

## Test plan
- [x] `pnpm --filter docs build` succeeds with Tailwind v4.2.4 (the previously-failing combination)
- [x] `npm pack --dry-run` includes `src/`, `LICENSE.md`, `NOTICE.md`, `README.md`, `package.json`; `dist/` will be added by `prepublishOnly` on actual publish
- [x] `pnpm -r lint` passes

## Follow-up
Once this lands, renovate/all can be rebased onto main and the `@tailwindcss/*` 4.2.2 → 4.2.4 bump will go through without additional fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)