### PR TITLE
ci: リリースフローを複合アクションに試験的に置き換え

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,14 +19,10 @@ jobs:
       (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(release):'))
     runs-on: ubuntu-24.04
     steps:
-      - uses: tuqulore/.github/setup@main
+      - uses: tuqulore/.github/setup@add-releasing-composite-action
         with:
           fetch-depth: 0
-
-      - name: Configure git
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
 
       - name: Publish to npm
         run: pnpm packages:publish --yes
@@ -41,25 +37,15 @@ jobs:
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
-      - name: Create alpha branch and bump version
-        run: |
-          git checkout main
-          git pull origin main
-          git checkout -b alpha
-          pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
-          git commit --all --message "chore(alpha): v$(cat lerna.json | jq -r .version)"
-          git push -f origin alpha
-
-      - name: Create alpha pull request
-        run: |
-          VERSION=$(cat lerna.json | jq -r .version)
-          gh pr create \
-            --base main \
-            --title "chore(alpha): v${VERSION}" \
-            --body "Bump to alpha version v${VERSION}"
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+        with:
+          branch: alpha
+          bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
+          version-command: jq -r .version lerna.json
+          commit-prefix: chore(alpha)
+          pr-body: Bump to alpha version v${VERSION}
+          github-token: ${{ github.token }}
 
       - name: Cleanup alpha branch on failure
-        if: failure()
+        if: cancelled() || failure()
         run: git push origin :alpha

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,30 +22,16 @@ jobs:
       group: release
       cancel-in-progress: true
     steps:
-      - uses: tuqulore/.github/setup@main
+      - uses: tuqulore/.github/setup@add-releasing-composite-action
+      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
+      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+        with:
+          branch: release
+          bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
+          version-command: jq -r .version lerna.json
+          commit-prefix: chore(release)
+          pr-body: Release v${VERSION}
+          github-token: ${{ github.token }}
 
-      - name: Configure git
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Create release branch and bump version
-        run: |
-          git checkout -b release
-          pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
-          VERSION=$(cat lerna.json | jq -r .version)
-          git commit --all --message "chore(release): v${VERSION}"
-          git push -f origin release
-
-      - name: Create pull request
-        run: |
-          VERSION=$(cat lerna.json | jq -r .version)
-          gh pr create \
-            --base main \
-            --title "chore(release): v${VERSION}" \
-            --body "Release v${VERSION}"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - if: failure()
+      - if: cancelled() || failure()
         run: git push origin :release


### PR DESCRIPTION
## 概要

リリースフローを `tuqulore/.github` の複合アクション（`configure-git` / `bump-and-pr`）に試験的に置き換えます。

関連: tuqulore/.github#15

## 変更内容

### `release.yaml`
- 「Configure git」「Create release branch and bump version」「Create pull request」の3ステップを `configure-git` + `bump-and-pr` に集約
- 失敗時クリーンアップを `if: cancelled() || failure()` に拡張

### `publish.yaml`
- 「Configure git」を `configure-git` に置換
- 「Create alpha branch and bump version」「Create alpha pull request」を `bump-and-pr` に置換
- npm publish・タグ作成ステップはそのまま維持
- クリーンアップを `if: cancelled() || failure()` に拡張

## 影響・留意点

- **強制 push の廃止**: `bump-and-pr` は通常 `git push` を使用。当リポジトリは `deleteBranchOnMerge: true` のため正常系は問題なし。concurrency キャンセル時のブランチ残留に備え、クリーンアップ条件を `cancelled() || failure()` へ拡張済み
- **参照ブランチ**: tuqulore/.github#15 が未マージのため、参照は実験ブランチ `@add-releasing-composite-action` を使用。**マージ後に `@main`（または SHA 固定）へ更新が必要**
- `ci.yaml` は `format` を SHA 固定で参照しており PR #15 の影響を受けないため、変更なし

## 確認手順

- [ ] `release.yaml` を `workflow_dispatch` で実行し、release PR が作成されること
- [ ] その PR を merge し、`publish.yaml` で npm publish・タグ作成・alpha PR 作成が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)