### PR TITLE
ci: リリースフローの複合アクション参照を @main に更新

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,10 +19,10 @@ jobs:
       (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(release):'))
     runs-on: ubuntu-24.04
     steps:
-      - uses: tuqulore/.github/setup@add-releasing-composite-action
+      - uses: tuqulore/.github/setup@main
         with:
           fetch-depth: 0
-      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
+      - uses: tuqulore/.github/configure-git@main
 
       - name: Publish to npm
         run: pnpm packages:publish --yes
@@ -37,7 +37,7 @@ jobs:
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
-      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+      - uses: tuqulore/.github/bump-and-pr@main
         with:
           branch: alpha
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,9 @@ jobs:
       group: release
       cancel-in-progress: true
     steps:
-      - uses: tuqulore/.github/setup@add-releasing-composite-action
-      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
-      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+      - uses: tuqulore/.github/setup@main
+      - uses: tuqulore/.github/configure-git@main
+      - uses: tuqulore/.github/bump-and-pr@main
         with:
           branch: release
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version


### PR DESCRIPTION
## 概要

リリースフローで使用している `tuqulore/.github` の複合アクション（`setup` / `configure-git` / `bump-and-pr`）の参照を、実験ブランチ `@add-releasing-composite-action` から `@main` へ更新します。

関連: #746 / tuqulore/.github#15

## 背景

#746 で導入した複合アクションベースのリリースフローを実験ブランチ参照で運用し、`v3.0.0` リリース・`v3.0.1-alpha.0` 生成まで動作確認が完了しました。

## 留意点

- ⚠️ **`tuqulore/.github#15` はまだ未マージ**で、`configure-git` / `bump-and-pr` は `tuqulore/.github` の `@main` にまだ存在しません
- `#15` がマージされるまで `release` / `publish` フローは実行しない前提で、先行して `@main` 固定にしています
- `#15` のマージ後、`@main` にアクションが反映されればリリースフローがそのまま動作します

## 変更内容

`release.yaml` / `publish.yaml` の以下の参照を `@add-releasing-composite-action` → `@main` に変更:

- `tuqulore/.github/setup`
- `tuqulore/.github/configure-git`
- `tuqulore/.github/bump-and-pr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)