### PR TITLE
docs: RELEASING.md に docs 修正フローと Cloudflare 構成を追記

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,6 +140,40 @@ main: 3.0.0
 - **手動で push しないでください。** CI 管理専用のブランチです。
 - alpha 公開（publish.yaml の手動実行）では更新されません。
 
+### docs の修正フロー
+
+修正対象によってフローが変わります。
+
+#### 最新メジャー（`v3`）の docs を直したい
+
+`main` ブランチに対して PR を作成・マージしてください。
+
+- `main` への変更は `jumpu-ui-alpha.pages.dev` に即時反映されます。
+- `jumpu-ui.pages.dev`（安定版）には **次の正式リリース時に自動反映** されます（CI が `main` を `v3` に上書き更新するため）。
+- 安定版へ即時反映したい場合は、`release.yaml` (patch) を実行してパッチリリースを切ってください。`v3` ブランチへの直接 push は採用しません（CI に上書きされるため）。
+
+#### 過去メジャー（`v1` / `v2`）の docs を直したい
+
+該当ブランチ（`v1` / `v2`）に対して直接 PR を作成・マージしてください。
+
+- v1/v2 は CI の自動更新対象外なので、push した内容がそのまま `jumpu-ui-v1.pages.dev` / `jumpu-ui-v2.pages.dev` に反映されます。
+- npm パッケージのリリースは不要です（docs のみのため）。
+
+#### 複数のメジャーに同じ修正を入れたい
+
+手動で cherry-pick してください。
+
+```bash
+# 例: main に入った修正を v2 にも入れる
+git fetch origin
+git checkout -b backport/<topic> origin/v2
+git cherry-pick <commit-on-main>
+git push -u origin backport/<topic>
+# v2 向けに PR を作成してマージ
+```
+
+頻度が増えてきたら、自動 backport ツール（例: `korthout/backport-action`）の導入を検討します。
+
 ### 新しいメジャーバージョンをリリースするとき
 
 `release.yaml` を `major` で実行すると、CI が新メジャーの `vX+1` ブランチを自動的に作成します（旧 `vX` ブランチはそのまま凍結されます）。あわせて Cloudflare Pages 側で以下の作業を行ってください。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -133,6 +133,19 @@ main: 3.0.0
 | https://jumpu-ui-v2.pages.dev/    | `v2`             | v2 系（凍結）                |
 | https://jumpu-ui-v1.pages.dev/    | `v1`             | v1 系（凍結）                |
 
+### Cloudflare Pages の構成
+
+各プロジェクトの本番ブランチとプレビュー対象は以下のとおりです。**どのブランチも必ず1プロジェクトでしかビルドされない** よう、`jumpu-ui-alpha` 側でメジャーブランチを ignore しています。
+
+| Project          | Production | Preview pattern | Ignore            |
+| ---------------- | ---------- | --------------- | ----------------- |
+| `jumpu-ui`       | `v3`       | `v3*`           | —                 |
+| `jumpu-ui-alpha` | `main`     | `*`             | `v1*` `v2*` `v3*` |
+| `jumpu-ui-v2`    | `v2`       | `v2*`           | —                 |
+| `jumpu-ui-v1`    | `v1`       | `v1*`           | —                 |
+
+ビルド設定はすべてのプロジェクトで共通です（新規プロジェクト作成時は既存の `jumpu-ui` プロジェクトと同じ内容をコピーしてください）。
+
 ### 安定ブランチ（`v3` など）について
 
 - `vX`（`v3` など）はメジャーごとの **安定版ドキュメント専用ブランチ** です。
@@ -176,11 +189,42 @@ git push -u origin backport/<topic>
 
 ### 新しいメジャーバージョンをリリースするとき
 
-`release.yaml` を `major` で実行すると、CI が新メジャーの `vX+1` ブランチを自動的に作成します（旧 `vX` ブランチはそのまま凍結されます）。あわせて Cloudflare Pages 側で以下の作業を行ってください。
+`release.yaml` を `major` で実行すると、CI が新メジャーの `vX+1` ブランチを自動的に作成します（旧 `vX` ブランチはそのまま凍結されます）。あわせて Cloudflare Pages と config 側で以下の作業を行ってください。
 
-1. 旧メジャー用プロジェクト（例: `jumpu-ui-v3`）を新規作成し、本番ブランチを旧 `vX` に設定する。
-2. `jumpu-ui` プロジェクトの本番ブランチを新メジャーの `vX+1` に変更する。
-3. `packages/docs/.vitepress/config.mts` の `nav` に旧メジャーへのリンクを追加する。
+以下は **v3 → v4 への切り替え** を例にした手順です（他メジャーへの切り替え時はバージョン数字を読み替えてください）。
+
+#### 1. 旧メジャー（v3）用プロジェクトを新規作成
+
+Cloudflare Pages で `jumpu-ui-v3` を新規作成し、以下を設定する：
+
+- Production branch: `v3`
+- Preview branch pattern: `v3*`
+- Build settings: 既存の `jumpu-ui` プロジェクトと同じ内容をコピー
+
+これで `https://jumpu-ui-v3.pages.dev/` が立ち上がります。
+
+#### 2. `jumpu-ui` プロジェクトを新メジャーに付け替え
+
+旧 v3 を専用プロジェクトに移したので、`jumpu-ui` を新メジャー `v4` に向ける：
+
+- Production branch: `v3` → `v4`
+- Preview branch pattern: `v3*` → `v4*`
+
+`https://jumpu-ui.pages.dev/` が v4 安定版のドキュメントになります。
+
+#### 3. `jumpu-ui-alpha` の ignore 更新
+
+メジャーブランチの重複ビルドを避けるため、`v4*` を ignore に追加する：
+
+- Ignore branch patterns: `v1*` `v2*` `v3*` → `v1*` `v2*` `v3*` `v4*`
+
+#### 4. `config.mts` の nav 更新
+
+`packages/docs/.vitepress/config.mts` の `nav.items` に旧 v3 へのリンクを追加する（main への PR としてマージ）：
+
+```js
+{ text: "v3", link: "https://jumpu-ui-v3.pages.dev/" },
+```
 
 ## 注意事項
 


### PR DESCRIPTION
## 背景

#750 で確立したドキュメントデプロイ構成（`v3` 安定ブランチ / `main` alpha / 凍結 v1・v2）に対し、運用ガイドが不足していた：

- docs を直したいときの手順がない
- Cloudflare Pages の preview / ignore 設定が文書化されていない
- 新メジャーリリース時の Pages 構築手順が簡略すぎる

## 変更内容

### docs の修正フロー（commit 1）

`## ドキュメントのデプロイ` に `### docs の修正フロー` を新設。

- 最新メジャー（v3）→ `main` への PR。安定版反映は次のリリース。即時必要なら patch
- 過去メジャー（v1/v2）→ 該当ブランチに直接 PR
- 複数メジャー共通の修正 → 手動 cherry-pick（頻度上昇時に自動 backport 検討）

### Cloudflare Pages 構成と新メジャー時の構築手順（commit 2）

- `### Cloudflare Pages の構成` を新設し、現在の各プロジェクトの production / preview / ignore 設定を表で明文化
- `### 新しいメジャーバージョンをリリースするとき` を v3→v4 を例とした 4 ステップに詳細化：
  1. 旧メジャー用 Pages プロジェクトを新規作成（prod=`v3`, preview=`v3*`）
  2. `jumpu-ui` プロジェクトを新メジャーに付け替え（prod=`v4`, preview=`v4*`）
  3. `jumpu-ui-alpha` の ignore に `v4*` を追加
  4. `config.mts` の nav に旧 v3 のリンクを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)