### PR TITLE
ci: release PR の本文に前回リリースタグとの比較リンクを追加

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           pr-body: |
             Release v${VERSION}
 
-            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.prev-tag.outputs.tag }}...v${VERSION}
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.prev-tag.outputs.tag }}...release
           github-token: ${{ github.token }}
 
       - if: cancelled() || failure()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,14 +23,26 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: tuqulore/.github/setup@main
+        with:
+          fetch-depth: 0
       - uses: tuqulore/.github/configure-git@main
+
+      - name: Determine previous release tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v -- '-' | head -n 1)
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+
       - uses: tuqulore/.github/bump-and-pr@main
         with:
           branch: release
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
           version-command: jq -r .version lerna.json
           commit-prefix: chore(release)
-          pr-body: Release v${VERSION}
+          pr-body: |
+            Release v${VERSION}
+
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.prev-tag.outputs.tag }}...v${VERSION}
           github-token: ${{ github.token }}
 
       - if: cancelled() || failure()


### PR DESCRIPTION
## Summary

- `tuqulore/.github/setup@main` に `fetch-depth: 0` を追加し、リリースタグの履歴を取得できるようにした
- 直前の安定リリースタグ (プレリリース `-alpha` 等を除外) を `git tag --list --sort=-version:refname` から取得するステップを追加
- `bump-and-pr` の `pr-body` に GitHub 標準形式の `**Full Changelog**: .../compare/<前回タグ>...v${VERSION}` 行を追加し、PR から差分を確認できるようにした

alpha 用の bump-and-pr は `publish.yaml` 側にあり今回は対象外。release ワークフロー (patch / minor / major) のみに反映される。

## Test plan

- [ ] Actions タブから `Release` ワークフローを `patch` で `workflow_dispatch` 実行し、作成された PR の本文に `**Full Changelog**: https://github.com/tuqulore/jumpu-ui/compare/v3.0.1...v3.0.2` 形式のリンクが含まれていることを確認
- [ ] 比較リンクを開き、`v3.0.1` から作成された PR ブランチまでの差分が表示されることを確認
- [ ] 失敗時に `release` ブランチがクリーンアップされる挙動が従来どおりであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)